### PR TITLE
Implement auto-format for misformatted agent messages

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -720,6 +720,12 @@ class Agent:
     async def process_tools(self, msg: str):
         # search for tool usage requests in agent message
         tool_request = extract_tools.json_parse_dirty(msg)
+        if tool_request is None:
+            auto = await self.call_extensions(
+                "message_autoformat", message=msg, loop_data=self.loop_data
+            )
+            if isinstance(auto, dict):
+                tool_request = auto
 
         if tool_request is not None:
             raw_tool_name = tool_request.get("tool_name", "")  # Get the raw tool name
@@ -829,5 +835,9 @@ class Agent:
             )
             cache[folder] = classes
 
+        result = None
         for cls in classes:
-            await cls(agent=self).execute(**kwargs)
+            res = await cls(agent=self).execute(**kwargs)
+            if res is not None:
+                result = res
+        return result

--- a/prompts/default/fw.msg_autoformat.md
+++ b/prompts/default/fw.msg_autoformat.md
@@ -1,24 +1,9 @@
-You are a message auto-formatter. Convert the following malformed agent response into proper JSON format.
+You responded with text that is not valid JSON. Convert the entire original response into the following JSON structure and return only that JSON.
 
-## Required JSON Format
-```json
 {
-    "thoughts": ["array of thoughts in natural language"],
-    "tool_name": "name_of_tool",
+    "thoughts": "I have misformatted my response, the system has automatically replaced it with proper JSON",
+    "tool_name": "response",
     "tool_args": {
-        "key": "value"
+        "text": "{{original_response}}"
     }
 }
-```
-
-## Auto-Formatting Rules
-1. If the response contains tool usage, extract the tool name and arguments
-2. If the response is plain text, use tool_name "response" with text in tool_args
-3. Generate appropriate thoughts explaining the conversion
-4. Preserve the original meaning and intent
-5. Return only valid JSON, no text before or after
-
-## Original Response to Format
-{{original_response}}
-
-Convert this to proper JSON format following the rules above.

--- a/python/extensions/message_autoformat/_10_autoformat_response.py
+++ b/python/extensions/message_autoformat/_10_autoformat_response.py
@@ -1,0 +1,20 @@
+from python.helpers.extension import Extension
+from agent import LoopData
+from langchain.prompts import ChatPromptTemplate
+from langchain.schema import SystemMessage
+from python.helpers import extract_tools
+
+class AutoformatResponse(Extension):
+    async def execute(self, message: str = "", loop_data: LoopData = LoopData(), **kwargs):
+        if not message:
+            return None
+        system = self.agent.read_prompt("fw.msg_autoformat.md", original_response=message)
+        prompt = ChatPromptTemplate.from_messages([SystemMessage(content=system)])
+        try:
+            response = await self.agent.call_chat_model(prompt)
+        except Exception:
+            return None
+        try:
+            return extract_tools.json_parse_dirty(response)
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary
- instruct LLM how to autoformat bad responses
- add autoformat extension to fix malformed JSON
- call `message_autoformat` extension when parsing fails
- allow `call_extensions` to return values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8f131cec83319e449d8912bcb40e